### PR TITLE
fix non-updating metrics from systemd-journal

### DIFF
--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -409,6 +409,10 @@ func (e *PostfixExporter) CollectLogfileFromJournal() error {
 	e.journal.Lock()
 	defer e.journal.Unlock()
 
+	r := e.journal.Wait(time.Duration(1) * time.Second)
+	if r < 0 {
+		log.Print("error while waiting for journal!")
+	}
 	for {
 		m, c, err := e.journal.NextMessage()
 		if err != nil {


### PR DESCRIPTION
Fixes #10 where metrics metrics collected from the
systemd journal were not updated after some time.

As explained in the issue, the change was taken from the [go-systemd](https://github.com/coreos/go-systemd/blob/d1b7d058aa2adfc795ad17ff4aaa2bc64ec11c78/sdjournal/journal_test.go#L493-L496) library.

cc/ @BartVerc @silkeh 