### PR TITLE
Add nosystemd build tag

### DIFF
--- a/nosystemd.go
+++ b/nosystemd.go
@@ -1,0 +1,21 @@
+// +build nosystemd
+// This file contains stubs to support non-systemd use
+
+package main
+
+import "io"
+
+type Journal struct {
+	io.Closer
+	Path string
+}
+
+func systemdFlags(enable *bool, unit, slice, path *string) {}
+
+func NewJournal(unit, slice, path string) (*Journal, error) {
+	return nil, nil
+}
+
+func (e *PostfixExporter) CollectLogfileFromJournal() error {
+	return nil
+}


### PR DESCRIPTION
This allows building the exporter without systemd headers, eg:

    env CGO_ENABLED=0 go build -tags nosystemd

Closes #11