### PR TITLE
When following log files, tail them rather than truncate them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,9 @@ command line flags.
 
 ## Events from log file
 
-The log file is truncated when
-processed, so that the next iteration doesn't interpret the same lines
-twice. It makes sense to configure your syslogger to multiplex log
-entries to a second file:
-
-```
-mail.* -/var/log/postfix_exporter_input.log
-```
-
-The path to the log file is specified with the `-postfix.logfile_path` flag.
+The log file is tailed when processed. Rotating the log files while the exporter
+is running is OK. The path to the log file is specified with the
+`-postfix.logfile_path` flag.
 
 ## Events from systemd
 


### PR DESCRIPTION
This change makes the exporter tail log files, meaning that the files can be opened read only and don't need to be truncated. This seems like a general all around win because:
 * It doesn't require any special syslog configuration to duplicate logs
 * The exporter process can be run by a user without write privileges to log files
 * This will likely work better out-of-the-box for most people