### PR TITLE
postfix_exporter.go: Handle the case where EOF is reached.

### DIFF
--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -78,7 +78,7 @@ type PostfixExporter struct {
 func CollectShowqFromReader(file io.Reader, ch chan<- prometheus.Metric) error {
 	reader := bufio.NewReader(file)
 	buf, err := reader.Peek(128)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		log.Printf("Could not read postfix output, %v", err)
 	}
 	if bytes.IndexByte(buf, 0) >= 0 {


### PR DESCRIPTION
Hi @BartVerc,

This handle the **EOF** case when scanning showq.

See these annoying messages,
```
Feb 06 13:34:03 hostname postfix_exporter[30713]: 2019/02/06 13:34:03 Could not read postfix output, EOF
Feb 06 13:34:27 hostname postfix_exporter[30713]: 2019/02/06 13:34:27 Could not read postfix output, EOF
Feb 06 13:35:27 hostname postfix_exporter[30713]: 2019/02/06 13:35:27 Could not read postfix output, EOF
Feb 06 13:36:27 hostname postfix_exporter[30713]: 2019/02/06 13:36:27 Could not read postfix output, EOF
Feb 06 13:37:27 hostname postfix_exporter[30713]: 2019/02/06 13:37:27 Could not read postfix output, EOF
Feb 06 13:38:27 hostname postfix_exporter[30713]: 2019/02/06 13:38:27 Could not read postfix output, EOF
Feb 06 13:39:27 hostname postfix_exporter[30713]: 2019/02/06 13:39:27 Could not read postfix output, EOF
Feb 06 13:40:27 hostname postfix_exporter[30713]: 2019/02/06 13:40:27 Could not read postfix output, EOF
Feb 06 13:41:27 hostname postfix_exporter[30713]: 2019/02/06 13:41:27 Could not read postfix output, EOF
Feb 06 13:42:27 hostname postfix_exporter[30713]: 2019/02/06 13:42:27 Could not read postfix output, EOF
```