### PR TITLE
Build binary with official golang image

### DIFF
--- a/build_static.sh
+++ b/build_static.sh
@@ -1,17 +1,15 @@
 #!/bin/sh
 
-docker run -i -v `pwd`:/postfix_exporter ubuntu:16.04 /bin/sh << 'EOF'
+docker run -i -v `pwd`:/postfix_exporter golang:1.12 /bin/sh << 'EOF'
 set -ex
 
 # Install prerequisites for the build process.
 apt-get update -q
-apt-get install -yq git golang-go libsystemd-dev
+apt-get install -yq libsystemd-dev
 
-mkdir /go
-export GOPATH=/go
 cd /postfix_exporter
 
 go get -d ./...
-go build --ldflags '-extldflags "-static"'
+go build -a -tags static_all
 strip postfix_exporter
 EOF


### PR DESCRIPTION
Ubuntu 16.04 use a very old Go version (1.6). It's better to use
official golang docker image with the latest golang release - 1.12.

Additionally I was able to fix #16 where `--systemd.enable` wasn't working correctly.