### PR TITLE
replace prometheus.Handler with promhttp.Handler

### DIFF
--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/hpcloud/tail"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -691,7 +692,7 @@ func main() {
 	}
 	prometheus.MustRegister(exporter)
 
-	http.Handle(*metricsPath, prometheus.Handler())
+	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, err = w.Write([]byte(`
 			<html>


### PR DESCRIPTION
prometheus.Handler was removed from the library after deprecation. I have replaced it with promhttp.Handler
This fixes #32 