### PR TITLE
#14: Removed leftover info about truncating the logfile. Also changed…

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 		listenAddress                                 = app.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9154").String()
 		metricsPath                                   = app.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 		postfixShowqPath                              = app.Flag("postfix.showq_path", "Path at which Postfix places its showq socket.").Default("/var/spool/postfix/public/showq").String()
-		postfixLogfilePath                            = app.Flag("postfix.logfile_path", "Path where Postfix writes log entries. This file will be truncated by this exporter.").Default("/var/log/postfix_exporter_input.log").String()
+		postfixLogfilePath                            = app.Flag("postfix.logfile_path", "Path where Postfix writes log entries.").Default("/var/log/maillog").String()
 		logUnsupportedLines                           = app.Flag("log.unsupported", "Log all unsupported lines.").Bool()
 		systemdEnable                                 bool
 		systemdUnit, systemdSlice, systemdJournalPath string


### PR DESCRIPTION
… the default to maillog since that is the normal file postfix uses.