### PR TITLE
fixes panic appears when tailer is nil

### DIFF
--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -612,6 +612,9 @@ func NewPostfixExporter(showqPath string, logfilePath string, journal *Journal, 
 func (e *PostfixExporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- postfixUpDesc
 
+	if e.tailer == nil {
+		return
+	}
 	ch <- e.cleanupProcesses.Desc()
 	ch <- e.cleanupRejects.Desc()
 	ch <- e.cleanupNotAccepted.Desc()
@@ -664,7 +667,7 @@ func (e *PostfixExporter) foreverCollectFromJournal(ctx context.Context) {
 func (e *PostfixExporter) StartMetricCollection(ctx context.Context) {
 	if e.journal != nil {
 		e.foreverCollectFromJournal(ctx)
-	} else {
+	} else if e.tailer != nil {
 		e.CollectLogfileFromFile(ctx)
 	}
 
@@ -697,6 +700,9 @@ func (e *PostfixExporter) Collect(ch chan<- prometheus.Metric) {
 			e.showqPath)
 	}
 
+	if e.tailer == nil {
+		return
+	}
 	ch <- e.cleanupProcesses
 	ch <- e.cleanupRejects
 	ch <- e.cleanupNotAccepted


### PR DESCRIPTION
A go panic occurs when the log file specification is empty.
The problem is that `Collect` works when the `tailer` is `nil`.

```
$ /bin/postfix_exporter --postfix.logfile_path=
```

```
$ kc logs -c exporter postfix-daemon-kr7mp
2020/04/22 03:09:38 Reading log events from 
2020/04/22 03:09:38 Listening on :9154
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x841538]

goroutine 10 [running]:
main.(*PostfixExporter).CollectLogfileFromFile(0xc0000c4dc0, 0xa02c60, 0xc00002d080)
	/go/src/github.com/kumina/postfix_exporter/postfix_exporter.go:433 +0xe8
main.(*PostfixExporter).StartMetricCollection(0xc0000c4dc0, 0xa02c60, 0xc00002d080)
	/go/src/github.com/kumina/postfix_exporter/postfix_exporter.go:671 +0x112
created by main.main
	/go/src/github.com/kumina/postfix_exporter/main.go:69 +0xedb
```