### PR TITLE
fixes an issue where can't get metrics in systemd journal

### DIFF
--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -612,7 +612,7 @@ func NewPostfixExporter(showqPath string, logfilePath string, journal *Journal, 
 func (e *PostfixExporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- postfixUpDesc
 
-	if e.tailer == nil {
+	if e.tailer == nil && e.journal == nil {
 		return
 	}
 	ch <- e.cleanupProcesses.Desc()
@@ -700,7 +700,7 @@ func (e *PostfixExporter) Collect(ch chan<- prometheus.Metric) {
 			e.showqPath)
 	}
 
-	if e.tailer == nil {
+	if e.tailer == nil && e.journal == nil {
 		return
 	}
 	ch <- e.cleanupProcesses


### PR DESCRIPTION
fixes https://github.com/kumina/postfix_exporter/issues/62.

I tested the ability to collect log metrics from the systemd journal.

```
$ diff -uwb 8e63fbbe 4dda5045 | grep ^\+\#\ TYPE
+# TYPE postfix_cleanup_messages_not_accepted_total counter
+# TYPE postfix_cleanup_messages_processed_total counter
+# TYPE postfix_cleanup_messages_rejected_total counter
+# TYPE postfix_qmgr_messages_inserted_receipients histogram
+# TYPE postfix_qmgr_messages_inserted_size_bytes histogram
+# TYPE postfix_qmgr_messages_removed_total counter
+# TYPE postfix_smtp_connection_timed_out_total counter
+# TYPE postfix_smtp_deferred_messages_total counter
+# TYPE postfix_smtp_status_deferred counter
+# TYPE postfix_smtpd_connects_total counter
+# TYPE postfix_smtpd_disconnects_total counter
+# TYPE postfix_smtpd_forward_confirmed_reverse_dns_errors_total counter
+# TYPE postfix_smtpd_sasl_authentication_failures_total counter
```
