### PR TITLE
Add some new metrics when parsing postfix logs

### DIFF
--- a/postfix_exporter_test.go
+++ b/postfix_exporter_test.go
@@ -34,6 +34,7 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 		smtpdSASLAuthenticationFailures prometheus.Counter
 		smtpdTLSConnects                *prometheus.CounterVec
 		bounceNonDelivery               prometheus.Counter
+		virtualDelivered                prometheus.Counter
 		unsupportedLogEntries           *prometheus.CounterVec
 	}
 	type args struct {
@@ -44,6 +45,7 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 		smtpdMessagesProcessed int
 		smtpMessagesProcessed  int
 		bounceNonDelivery  int
+		virtualDelivered       int
 	}
 	tests := []struct {
 		name   string
@@ -197,6 +199,18 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 				bounceNonDelivery: prometheus.NewCounter(prometheus.CounterOpts{}),
 			},
 		},
+		{
+			name: "Testing virtual delivered",
+			args: args{
+				line: []string{
+					"Apr  7 15:35:20 123-mail postfix/virtual[20235]: 199041033BE: to=<me@domain.fr>, relay=virtual, delay=0.08, delays=0.08/0/0/0, dsn=2.0.0, status=sent (delivered to maildir)",
+				},
+				virtualDelivered: 1,
+			},
+			fields: fields{
+				virtualDelivered: prometheus.NewCounter(prometheus.CounterOpts{}),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -225,6 +239,7 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 				smtpdSASLAuthenticationFailures: tt.fields.smtpdSASLAuthenticationFailures,
 				smtpdTLSConnects:                tt.fields.smtpdTLSConnects,
 				bounceNonDelivery:               tt.fields.bounceNonDelivery,
+				virtualDelivered:                tt.fields.virtualDelivered,
 				unsupportedLogEntries:           tt.fields.unsupportedLogEntries,
 				logUnsupportedLines:             true,
 			}
@@ -237,6 +252,7 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 			assertCounterEquals(t, e.smtpdProcesses, tt.args.smtpdMessagesProcessed, "Wrong number of smtpd messages processed")
 			assertCounterEquals(t, e.smtpProcesses, tt.args.smtpMessagesProcessed, "Wrong number of smtp messages processed")
 			assertCounterEquals(t, e.bounceNonDelivery, tt.args.bounceNonDelivery, "Wrong number of non delivery notifications")
+			assertCounterEquals(t, e.virtualDelivered, tt.args.virtualDelivered, "Wrong number of delivered mails")
 		})
 	}
 }

--- a/postfix_exporter_test.go
+++ b/postfix_exporter_test.go
@@ -33,6 +33,7 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 		smtpdRejects                    *prometheus.CounterVec
 		smtpdSASLAuthenticationFailures prometheus.Counter
 		smtpdTLSConnects                *prometheus.CounterVec
+		bounceNonDelivery               prometheus.Counter
 		unsupportedLogEntries           *prometheus.CounterVec
 	}
 	type args struct {
@@ -42,6 +43,7 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 		outgoingTLS            int
 		smtpdMessagesProcessed int
 		smtpMessagesProcessed  int
+		bounceNonDelivery  int
 	}
 	tests := []struct {
 		name   string
@@ -185,12 +187,14 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 					"Dec 29 03:03:48 mail postfix/bounce[9321]: 732BB407C3: sender non-delivery notification: 5DE184083C",
 				},
 				smtpMessagesProcessed:  2,
+				bounceNonDelivery: 1,
 			},
 			fields: fields{
 				unsupportedLogEntries: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"process"}),
 				smtpDelays: prometheus.NewHistogramVec(prometheus.HistogramOpts{}, []string{"stage"}),
 				smtpStatusDeferred: prometheus.NewCounter(prometheus.CounterOpts{}),
 				smtpProcesses: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"status"}),
+				bounceNonDelivery: prometheus.NewCounter(prometheus.CounterOpts{}),
 			},
 		},
 	}
@@ -220,6 +224,7 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 				smtpdRejects:                    tt.fields.smtpdRejects,
 				smtpdSASLAuthenticationFailures: tt.fields.smtpdSASLAuthenticationFailures,
 				smtpdTLSConnects:                tt.fields.smtpdTLSConnects,
+				bounceNonDelivery:               tt.fields.bounceNonDelivery,
 				unsupportedLogEntries:           tt.fields.unsupportedLogEntries,
 				logUnsupportedLines:             true,
 			}
@@ -231,6 +236,7 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 			assertCounterEquals(t, e.smtpTLSConnects, tt.args.outgoingTLS, "Wrong number of TLS connections counted")
 			assertCounterEquals(t, e.smtpdProcesses, tt.args.smtpdMessagesProcessed, "Wrong number of smtpd messages processed")
 			assertCounterEquals(t, e.smtpProcesses, tt.args.smtpMessagesProcessed, "Wrong number of smtp messages processed")
+			assertCounterEquals(t, e.bounceNonDelivery, tt.args.bounceNonDelivery, "Wrong number of non delivery notifications")
 		})
 	}
 }


### PR DESCRIPTION
Hello,

Thank you very much for this exporter !

I needed some other metrics, so I tried to add them.
I'm not fluent in go, so let me know if you want me to change something, I will gladly do it.

I also stumbled upon a duplicated metric, that is now included as well in one metric I added. I can clean it up if you want:
* smtp_deferred_messages_total stored in smtpDeferreds  (which doesn't work)
* smtp_status_deferred stored in smtpStatusDeferred
* And that's the same as the new smtpProcesses metric with the label {status=deferred}

Thomas