### PR TITLE
Fix: Default for mail log path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3 / 2021-05-02
+
+* [BUGFIX] Fix default for mail log path (/var/log/mail.log)
+
 ## 0.1.2 / 2018-05-04
 
 * [ENHANCEMENT] Build tag for systemd

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These options can be used when starting the `postfix_exporter`
 | `--web.listen-address`   | Address to listen on for web interface and telemetry | `9154`                            |
 | `--web.telemetry-path`   | Path under which to expose metrics                   | `/metrics`                        |
 | `--postfix.showq_path`   | Path at which Postfix places its showq socket        | `/var/spool/postfix/public/showq` |
-| `--postfix.logfile_path` | Path where Postfix writes log entries                | `/var/log/maillog`                |
+| `--postfix.logfile_path` | Path where Postfix writes log entries                | `/var/log/mail.log`               |
 | `--log.unsupported`      | Log all unsupported lines                            | `false`                           |
 | `--docker.enable`        | Read from the Docker logs instead of a file          | `false`                           |
 | `--docker.container.id`  | The container to read Docker logs from               | `postfix`                         |

--- a/logsource_file.go
+++ b/logsource_file.go
@@ -66,7 +66,7 @@ type fileLogSourceFactory struct {
 }
 
 func (f *fileLogSourceFactory) Init(app *kingpin.Application) {
-	app.Flag("postfix.logfile_path", "Path where Postfix writes log entries.").Default("/var/log/maillog").StringVar(&f.path)
+	app.Flag("postfix.logfile_path", "Path where Postfix writes log entries.").Default("/var/log/mail.log").StringVar(&f.path)
 }
 
 func (f *fileLogSourceFactory) New(ctx context.Context) (LogSourceCloser, error) {


### PR DESCRIPTION
The default for the log path had a typo and the dot was missing