### PR TITLE
Don't bail out from systemd log reader when reaching the end

### DIFF
--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -634,7 +634,6 @@ func (e *PostfixExporter) StartMetricCollection(ctx context.Context) {
 			if err != io.EOF {
 				log.Printf("Couldn't read journal: %v", err)
 			}
-			return
 		}
 		e.CollectFromLogLine(line)
 		gauge.Set(1)


### PR DESCRIPTION
The log search starts at the current time, i.e. the end of the journal
(`SeekTail()` / `SeekRealtimeUsec`) and thus runs into an EOF.

Not a big deal because the code takes care of that, but the log-reading
loop is exited then and further messages are ignored.

Potentially fixes #55.